### PR TITLE
feat: layout新增搜索页是私有的头部

### DIFF
--- a/6-layout/src/App.vue
+++ b/6-layout/src/App.vue
@@ -10,11 +10,13 @@
 <script>
 import DefaultLayout from '@/layouts/Default.vue';
 import FullWidthLayout from '@/layouts/FullWidth.vue';
+import FullWidthSearch from '@/layouts/FullWidthSearch.vue';
 
 export default {
   components: {
     Default: DefaultLayout,
     FullWidth: FullWidthLayout,
+    FullWidthSearch,
   },
 
   computed: {

--- a/6-layout/src/components/Search.vue
+++ b/6-layout/src/components/Search.vue
@@ -1,0 +1,40 @@
+<template>
+  <header class="search-header">
+    <label>
+      <span class="mr10">搜索页是私有的头部</span>
+      <input type="text" class="search-header-input">
+    </label>
+  </header>
+</template>
+
+<script>
+export default {
+  name: 'Search',
+};
+</script>
+
+<style lang="scss" scoped>
+.search-header {
+  height: 80px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #cee;
+
+  &-input {
+    display: inline-block;
+    width: 400px;
+    height: 30px;
+    border-radius: 3px;
+    outline: none;
+    margin-top: 20px;
+    border: solid 1px #ccc;
+    padding-left: 6px;
+    transition: border-color 0.3s;
+
+    &:focus {
+      border-color: #739fe2;
+    }
+  }
+}
+</style>

--- a/6-layout/src/config/router.js
+++ b/6-layout/src/config/router.js
@@ -3,12 +3,16 @@ module.exports = [
     path: '/',
     component: () => import(/* webpackChunkName: "page-index" */'@/pages/Index.vue'),
     meta: {
-      layout: 'FullWidth',
+      layout: 'FullWidthSearch',
     },
   },
   {
     path: '/view/:id/',
     component: () => import(/* webpackChunkName: "page-view" */'@/pages/view/Index.vue'),
+    meta: {
+      layout: 'FullWidthSearch',
+      fullWidth: false, // 关闭全屏宽度
+    },
   },
   {
     path: '*',

--- a/6-layout/src/config/site.js
+++ b/6-layout/src/config/site.js
@@ -14,4 +14,3 @@ export const locales = [
  * @type {string}
  */
 export const locale = 'zh-cn';
-

--- a/6-layout/src/layouts/FullWidthSearch.vue
+++ b/6-layout/src/layouts/FullWidthSearch.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="layout-full" :class="width">
+    <main>
+      <search/>
+      <my-locale class="mt20" />
+      <router-view></router-view>
+    </main>
+    <my-footer/>
+  </div>
+</template>
+
+<script>
+import Search from '@/components/Search.vue';
+import MyLocale from '@/components/Locale.vue';
+import MyFooter from '@/components/Footer.vue';
+
+export default {
+  name: 'FullWidthSearch',
+  components: {
+    Search,
+    MyLocale,
+    MyFooter,
+  },
+  computed: {
+    width() {
+      // 不设置 fullWidth, 默认为全屏宽度
+      const { fullWidth = true } = this.$route.meta;
+      return fullWidth ? '' : 'c-page-width';
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+  // 吸底样式
+  .layout-full {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+
+    > main {
+      flex: 1 1 auto;
+    }
+  }
+</style>


### PR DESCRIPTION
大佬你好, 有一个疑问。

`但随着项目越来越大，页面越来越多，需求层出不穷`  

- 每一个不可复用的另类的需求都需要一个新的Layout组件么

- 所提交的代码, 完善了搜索页是私有的头部, 是你所想的新建一个 Layout组件么 

- 如果主页面的搜索页是私有的头部 和 详情页面的搜索页是私有的头部 是两个完全不同的搜索, 你认为是再新建一个统一类型的Layout组件比较好还是在 `FullWidthSearch` 的 search组件改为动态组件, 分别加载主页面的搜索组件和详情页的搜索组件较好呢  

希望向你学习